### PR TITLE
fix(docs): isolate canvas-runtime CSS from docs chrome in example previews

### DIFF
--- a/docs/src/components/Example.tsx
+++ b/docs/src/components/Example.tsx
@@ -9,6 +9,7 @@ import {
 } from "@olympusoss/canvas";
 import { type ReactNode, useEffect, useState } from "react";
 import Frame, { FrameContextConsumer } from "react-frame-component";
+import canvasRuntimeCssUrl from "../../../styles/canvas.css?url";
 import { DocsCodeBlock } from "./DocsCodeBlock";
 
 type Viewport = "desktop" | "tablet" | "mobile";
@@ -36,27 +37,23 @@ interface ExampleProps {
 }
 
 /**
- * Build the iframe's `<head>` by cloning every `<link rel="stylesheet">` and
- * `<style>` tag from the parent document. Lets Vite-injected CSS (Tailwind v4
- * @source / @theme inline output) reach the frame so canvas tokens resolve
- * inside the example's own viewport.
+ * Iframe head: a single <link> pointing at the compiled canvas-runtime
+ * stylesheet (canvas/styles/canvas.css), resolved via Vite `?url`.
  *
- * Captured ONCE on mount and never updated. We deliberately don't observe
- * `document.head` — some libraries (input-otp's noScriptCSSFallback, etc.)
- * inject `<style>` tags lazily when they mount inside the iframe, which
- * mutates the parent document.head, which would re-fire a MutationObserver
- * and re-mount the iframe → re-mount the library → infinite loop.
+ * Why this beats cloning parent <style>/<link> tags:
+ *   - In dev Vite injects every imported CSS module as its own <style> tag,
+ *     but in prod they're all bundled into one hashed stylesheet — so any
+ *     filter that tries to keep "only canvas.css" from the parent doc
+ *     either keeps the bundled file (defeating isolation) or drops it
+ *     (leaving examples unstyled). `?url` sidesteps the question by giving
+ *     us a stable URL to the canvas-runtime asset in BOTH modes.
+ *   - `?url` resolves through Vite's full pipeline including @tailwindcss/vite,
+ *     so the served file is the compiled output (Tailwind utilities scanned
+ *     from canvas/src + tokens + leaflet) — exactly what an example needs.
+ *   - The iframe ends up with ONLY canvas-runtime CSS. No docs chrome
+ *     (sidebar, hero, prose, animations) leaks in. Mirrors a real consumer
+ *     app's render environment.
  */
-function useFrameHead() {
-	const [head, setHead] = useState("");
-	useEffect(() => {
-		const collected = Array.from(document.querySelectorAll('link[rel="stylesheet"], style'))
-			.map((el) => el.outerHTML)
-			.join("\n");
-		setHead(collected);
-	}, []);
-	return head;
-}
 
 /** Mirror the page's dark-mode class onto the iframe's <html>. */
 function useDarkClassMirror(doc: Document | undefined) {
@@ -156,9 +153,8 @@ interface PreviewFrameProps {
 }
 
 function PreviewFrame({ viewport, children }: PreviewFrameProps) {
-	const head = useFrameHead();
 	const [height, setHeight] = useState(MIN_FRAME_HEIGHT);
-	const initialContent = `<!DOCTYPE html><html style="overflow:hidden;"><head>${head}</head><body style="margin:0;background:transparent;"><div id="frame-root"></div></body></html>`;
+	const initialContent = `<!DOCTYPE html><html style="overflow:hidden;"><head><link rel="stylesheet" href="${canvasRuntimeCssUrl}"></head><body style="margin:0;background:transparent;"><div id="frame-root"></div></body></html>`;
 
 	return (
 		<div
@@ -175,7 +171,6 @@ function PreviewFrame({ viewport, children }: PreviewFrameProps) {
 			}}
 		>
 			<Frame
-				key={head ? "ready" : "loading"}
 				initialContent={initialContent}
 				mountTarget="#frame-root"
 				style={{

--- a/docs/src/main.tsx
+++ b/docs/src/main.tsx
@@ -3,8 +3,8 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { router } from "./router";
+import "../../styles/canvas.css";
 import "./styles.css";
-import "../../styles/leaflet.css";
 
 const browserRouter = createBrowserRouter(router, {
 	basename: import.meta.env.BASE_URL,

--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -1,93 +1,32 @@
+/* ---------- Canvas docs site chrome ----------
+ *
+ * This file owns the docs site's shell — sidebar, hero, layout, prose,
+ * code blocks, brand utilities, scrollbars, animations.
+ *
+ * Two independent Tailwind compilations on the page:
+ *   - canvas/styles/canvas.css → emits its own <style>, scans canvas/src,
+ *     carries the `--canvas-runtime` sentinel. The per-example iframe
+ *     keeps ONLY this one. Loaded first via main.tsx.
+ *   - this file → emits its own <style>, scans docs/src for utility classes
+ *     used in docs JSX/MDX. The iframe filters this out.
+ *
+ * Both stylesheets share the canonical CSS variables exposed on :root by
+ * canvas.css (tokens.css + @theme inline). Do NOT redeclare canvas tokens
+ * here — silent overrides cause visual drift (e.g. flattened card elevation
+ * in dark mode).
+ */
+
 @import "tailwindcss";
-@source "../../src/**/*.{ts,tsx}";
-@import "../../styles/tokens.css";
-
-@theme inline {
-	--color-background: hsl(var(--background));
-	--color-foreground: hsl(var(--foreground));
-	--color-card: hsl(var(--card));
-	--color-card-foreground: hsl(var(--card-foreground));
-	--color-popover: hsl(var(--popover));
-	--color-popover-foreground: hsl(var(--popover-foreground));
-	--color-primary: hsl(var(--primary));
-	--color-primary-foreground: hsl(var(--primary-foreground));
-	--color-secondary: hsl(var(--secondary));
-	--color-secondary-foreground: hsl(var(--secondary-foreground));
-	--color-muted: hsl(var(--muted));
-	--color-muted-foreground: hsl(var(--muted-foreground));
-	--color-accent: hsl(var(--accent));
-	--color-accent-foreground: hsl(var(--accent-foreground));
-	--color-destructive: hsl(var(--destructive));
-	--color-destructive-foreground: hsl(var(--destructive-foreground));
-	--color-brand: hsl(var(--brand));
-	--color-brand-foreground: hsl(var(--brand-foreground));
-	--color-border: hsl(var(--border));
-	--color-input: hsl(var(--input));
-	--color-ring: hsl(var(--ring));
-}
-
-@custom-variant dark (&:is(.dark *));
-
-/* ---------- Light theme — canonical canvas tokens ----------
- * Use canvas's pure-white --background so the blue-tinted --sidebar
- * (hue 230) reads as designed. The previous override at 220 16% 97% had
- * the same lightness as --sidebar, making the sidebar tint disappear.
- */
-:root {
-	--background: 0 0% 100%;
-	--foreground: 240 10% 3.9%;
-	--card: 0 0% 100%;
-	--card-foreground: 240 10% 3.9%;
-	--popover: 0 0% 100%;
-	--popover-foreground: 240 10% 3.9%;
-	--primary: 240 5.9% 10%;
-	--primary-foreground: 0 0% 98%;
-	--secondary: 240 4.8% 95.9%;
-	--secondary-foreground: 240 5.9% 10%;
-	--muted: 240 4.8% 95.9%;
-	--muted-foreground: 240 3.8% 46.1%;
-	--accent: 240 4.8% 95.9%;
-	--accent-foreground: 240 5.9% 10%;
-	--border: 240 5.9% 90%;
-	--input: 240 5.9% 90%;
-	--ring: 240 5.9% 10%;
-}
-
-/* ---------- Dark theme — canonical canvas tokens ----------
- * Canvas's canonical dark --background is `240 10% 3.9%`. The previous
- * override at `224 12% 10%` had the same lightness as the dark sidebar
- * (`230 12% 10%`), making the sidebar tint disappear in dark mode.
- */
-.dark {
-	--background: 240 10% 3.9%;
-	--foreground: 0 0% 98%;
-	--card: 240 10% 3.9%;
-	--card-foreground: 0 0% 98%;
-	--popover: 240 10% 3.9%;
-	--popover-foreground: 0 0% 98%;
-	--primary: 0 0% 98%;
-	--primary-foreground: 240 5.9% 10%;
-	--secondary: 240 3.7% 15.9%;
-	--secondary-foreground: 0 0% 98%;
-	--muted: 240 3.7% 15.9%;
-	--muted-foreground: 240 5% 64.9%;
-	--accent: 240 3.7% 15.9%;
-	--accent-foreground: 0 0% 98%;
-	--border: 240 3.7% 15.9%;
-	--input: 240 3.7% 15.9%;
-	--ring: 240 4.9% 83.9%;
-}
+@source "./**/*.{ts,tsx,mdx}";
 
 /* ---------- Base ---------- */
 body {
 	font-family: "Inter", system-ui, -apple-system, sans-serif;
-	background: hsl(var(--background));
-	color: hsl(var(--foreground));
 	font-feature-settings: "ss01", "cv11";
 }
 
 /* ---------- Brand gradient utilities ----------
- * The Olympus blue gradient is the only saturated chrome in Canvas.
+ * The Olympus blue gradient is the only saturated chrome in Canvas docs.
  * Use sparingly: hero H1, ring decoration, occasional accent dots.
  */
 :root {
@@ -220,19 +159,6 @@ body[data-density="comfortable"] .nav-link { padding: 8px 12px; font-size: 13.5p
 
 /* ---------- Component page anchor offset (sticky TOC) ---------- */
 .scroll-mt-anchor { scroll-margin-top: 96px; }
-
-/* ---------- Example preview body — mirrors the consuming app's page bg ---
- * Reads `--background` directly so previews show components against the
- * exact same surface a real Athena/Hera/Site page would render against.
- * In dark mode this reveals the proper card-vs-body elevation lift; in
- * light mode body and card are both white and borders define the card.
- * Tokens are NOT redeclared here, so canvas components inside inherit
- * whichever theme (light :root / dark .dark) is active on the document.
- */
-.example-preview-body {
-	background: hsl(var(--background));
-	color: hsl(var(--foreground));
-}
 
 /* ---------- Shiki overrides ---------- */
 .docs-shiki .shiki { background: transparent !important; }

--- a/styles/canvas.css
+++ b/styles/canvas.css
@@ -1,0 +1,54 @@
+/* ---------- Canvas lib runtime entry ----------
+ *
+ * The single CSS import that gives a consumer Canvas's full styling contract:
+ *   - Tailwind v4 with @source pointed at canvas/src
+ *   - Canonical design tokens (light + dark, tiered surfaces, sidebar, stat-card)
+ *   - @theme inline mapping so `bg-card`, `text-foreground`, etc. resolve
+ *   - Leaflet defaults for canvas/components/molecules/leaflet-map and scalable-globe
+ *
+ * Consumers (athena/hera/site/daedalus) and the canvas-docs site both import
+ * this file. Inside canvas-docs, the per-example iframe filters parent
+ * stylesheets down to ONLY this one — the sentinel rule below
+ * (`--canvas-runtime`) is what the filter looks for. Keep that rule.
+ */
+
+@import "tailwindcss";
+@source "../src/**/*.{ts,tsx}";
+@import "./tokens.css";
+@import "./leaflet.css";
+
+@theme inline {
+	--color-background: hsl(var(--background));
+	--color-foreground: hsl(var(--foreground));
+	--color-card: hsl(var(--card));
+	--color-card-foreground: hsl(var(--card-foreground));
+	--color-popover: hsl(var(--popover));
+	--color-popover-foreground: hsl(var(--popover-foreground));
+	--color-primary: hsl(var(--primary));
+	--color-primary-foreground: hsl(var(--primary-foreground));
+	--color-secondary: hsl(var(--secondary));
+	--color-secondary-foreground: hsl(var(--secondary-foreground));
+	--color-muted: hsl(var(--muted));
+	--color-muted-foreground: hsl(var(--muted-foreground));
+	--color-accent: hsl(var(--accent));
+	--color-accent-foreground: hsl(var(--accent-foreground));
+	--color-destructive: hsl(var(--destructive));
+	--color-destructive-foreground: hsl(var(--destructive-foreground));
+	--color-brand: hsl(var(--brand));
+	--color-brand-foreground: hsl(var(--brand-foreground));
+	--color-border: hsl(var(--border));
+	--color-input: hsl(var(--input));
+	--color-ring: hsl(var(--ring));
+}
+
+/* ---------- Iframe-filter sentinel ----------
+ * Do NOT remove. The canvas-docs Example wrapper uses this token to identify
+ * the canvas-runtime stylesheet among all parent-document styles when cloning
+ * into the per-example iframe. Stripping this rule will cause example
+ * components to render unstyled inside the docs preview.
+ */
+@layer canvas-runtime {
+	:root {
+		--canvas-runtime: 1;
+	}
+}


### PR DESCRIPTION
## Summary

The per-example iframe at `/components/{tier}/{name}` rendered components against a stylesheet that mixed canvas-lib tokens with docs-site chrome. Two leaks compounded:

1. A duplicated `:root`/`.dark` block in `docs/src/styles.css` overrode the canonical canvas tokens. In dark mode it set `--card: 240 10% 3.9%` (= `--background`), flattening the L0→L2 surface elevation the handoff specifies.
2. `useFrameHead` cloned every `<link>`/`<style>` from `document.head` into the iframe, so sidebar nav, prose, brand utilities, and hero animations all leaked into the preview.

This PR separates the three CSS surfaces:

- **Canvas lib** — `canvas/src` + `canvas/styles/{tokens,canvas,leaflet}.css`
- **Canvas examples** (iframes) — `canvas.css` only
- **Canvas docs** — `canvas.css` + `docs/src/styles.css` (chrome)

## Changes

- **NEW** `canvas/styles/canvas.css` — canvas-lib runtime entry: `@import "tailwindcss"` + `@source "../src/**"` + tokens + leaflet + `@theme inline`. Public via the existing `"./styles/*"` package export. Carries a `--canvas-runtime` sentinel for inspection.
- **REWROTE** `canvas/docs/src/styles.css` — docs chrome only. Independent Tailwind compilation scanning `docs/src`. The duplicated `:root`/`.dark` blocks are gone; canonical `tokens.css` wins.
- **EDITED** `canvas/docs/src/components/Example.tsx` — `useFrameHead` removed. Iframes mount a single `<link>` pointing at `canvas.css` via Vite `?url` import. Works identically in dev (served as `/styles/canvas.css?...`) and prod (emitted as `canvas-[hash].css`).
- **EDITED** `canvas/docs/src/main.tsx` — `canvas.css` imported explicitly; the standalone `leaflet.css` import drops (leaflet now travels with `canvas.css`).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run test` — 674/674 pass
- [x] `bun run lint` — no new warnings
- [x] `bun run build` (docs) — emits separate `canvas-[hash].css` (126KB, sentinel, no chrome rules) and `index-[hash].css` (chrome + parent-page bundle)
- [x] Visual: `/components/molecules/card` in dark mode — body `rgb(12,13,19)` (canonical L0), card `rgb(27,30,39)` (canonical L2). Handoff matched.
- [x] Visual: light mode unchanged — borders + shadow define cards on white body.
- [x] Iframe DOM check: 1 `<link>` to `canvas.css`, 0 inline `<style>`, no `.docs-prose`/`.nav-link`/`.brand-wash`.
- [x] Docs chrome on `/`: hero gradient text, brand-wash, logo shimmer, sidebar active state, code blocks all render.
- [x] Spot-checked atoms (button), molecules (card), charts (composed-chart) — all iframes show 1 link to canvas.css and render correctly.