### PR TITLE
ci: delta tests on feature-branch pushes, full suite on main + PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,24 @@ name: CI — canvas
 
 on:
   push:
-    branches: [main]
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'package.json'
+      - 'bun.lock'
+      - 'tsconfig*.json'
+      - 'vitest.config.*'
+      - 'biome.json'
+      - 'size-limit.config.*'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
   workflow_dispatch:
+
+# Fresh push to the same ref cancels the prior in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -13,8 +27,15 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Gate runs (PR + push to main) run the full suite.
+      # Non-gate runs (feature-branch push) run lint + typecheck + delta unit only.
+      IS_GATE: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          # `vitest --changed origin/main` needs the merge base.
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -28,14 +49,22 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Run vitest
+      - name: Run vitest (delta — feature branch)
+        if: env.IS_GATE != 'true'
+        run: bunx vitest run --changed origin/main
+
+      - name: Run vitest (full — PR or main)
+        if: env.IS_GATE == 'true'
         run: bun run test
 
       - name: Snapshot coverage gate (100%)
+        if: env.IS_GATE == 'true'
         run: bun run snapshot-coverage
 
       - name: Coverage
+        if: env.IS_GATE == 'true'
         run: bun run test:coverage
 
       - name: Bundle size
+        if: env.IS_GATE == 'true'
         run: bun run size


### PR DESCRIPTION
## Summary

- Adds push-to-any-branch trigger with a paths filter (canvas had none).
- New \`IS_GATE\` env gates the slow steps: \`snapshot-coverage\`, \`test:coverage\`, \`size\`.
- Feature-branch push: lint + typecheck + \`vitest run --changed origin/main\`.
- PR + main: unchanged — full suite.
- \`fetch-depth: 0\` for vitest merge-base diff.
- \`concurrency: ci-<ref>\` cancels stacked runs.

## Test plan

- [ ] This PR runs full mode (event_name=pull_request).
- [ ] After merge, push to a feature branch and verify only lint/typecheck/delta run.