### PR TITLE
fix(checkbox): stop the native-Android box collapsing to a sliver

### DIFF
--- a/.changeset/checkbox-android-box-collapse.md
+++ b/.changeset/checkbox-android-box-collapse.md
@@ -1,0 +1,14 @@
+---
+"@olympusoss/canvas": patch
+---
+
+Fix the Checkbox box collapsing to a thin vertical sliver on native Android
+(Fabric). A checked/indeterminate box rendered its check/dash as an in-flow
+`<Text>` child, and on the New Architecture an in-flow text node drives its
+parent View's main-axis size and overrode the box's explicit `width` — an 18dp
+square shrank to the glyph's ~5dp measured width while the cross-axis `height`
+was honored. (Radio never hit this: its checked child is a `<View>` dot, not
+text.) The glyph now sits on its own absolutely-positioned, flex-centered layer,
+so it is out of the box's content flow and `width` wins. The layer centers
+identically on iOS, react-native-web, and native Android, so the look is
+unchanged on every platform; only the collapsed Android box is fixed.

--- a/src/atoms/checkbox/checkbox.shared.tsx
+++ b/src/atoms/checkbox/checkbox.shared.tsx
@@ -65,6 +65,27 @@ export interface CheckboxSkin {
 // The row: box + optional label, top-aligned so a multi-line label hangs from the box.
 const ROW: ViewStyle = { flexDirection: "row", alignItems: "flex-start", gap: 8 };
 
+// The glyph sits on its own absolutely-positioned layer that fills the box and
+// centers the check/dash with flexbox. This is deliberate: on native Android
+// (Fabric) an IN-FLOW <Text> child drives its parent View's main-axis size and
+// overrides the box's explicit `width`, collapsing the box to the glyph's measured
+// width (~5dp) while the cross-axis `height` is honored — an 18dp square renders as
+// a thin vertical sliver. (The Radio never hits this: its checked child is a <View>
+// dot, not text.) Taking the glyph out of flow removes it from the box's content
+// measurement, so `width` wins. Absolute + flex-center behaves identically on iOS,
+// react-native-web, and native Android, so this is a cross-platform fix, not a
+// per-platform escape hatch — the look is unchanged everywhere.
+const GLYPH_LAYER: ViewStyle = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  alignItems: "center",
+  justifyContent: "center",
+  pointerEvents: "none", // the Pressable owns the touch; keep this layer inert
+};
+
 /** Build a Checkbox component from a platform skin. */
 export function createCheckbox(skin: CheckboxSkin) {
   return function Checkbox(props: CheckboxProps) {
@@ -113,7 +134,11 @@ export function createCheckbox(skin: CheckboxSkin) {
         ]}
       >
         <View style={skin.box(tokens, filled, size)}>
-          {filled ? <Text style={skin.glyph(tokens, size)}>{glyph}</Text> : null}
+          {filled ? (
+            <View style={GLYPH_LAYER}>
+              <Text style={skin.glyph(tokens, size)}>{glyph}</Text>
+            </View>
+          ) : null}
         </View>
         {children != null ? <Text style={skin.label(tokens, size)}>{children}</Text> : null}
       </Pressable>


### PR DESCRIPTION
## Problem

On native Android (Fabric / New Architecture) the Checkbox box **collapses horizontally into a ~5dp-wide vertical sliver** whenever it is checked or indeterminate. Height is correct (18dp box + 2dp `marginTop`), but width is dropped — a checked box renders as a thin indigo vertical bar instead of an 18dp square. iOS and web (including the docs 3-up preview) are unaffected.

## Root cause

A filled box rendered its check/dash as an **in-flow `<Text>` child**:

```tsx
<View style={box}>{filled ? <Text style={glyph}>{glyph}</Text> : null}</View>
```

On Fabric, an in-flow `<Text>` child drives its parent `View`'s **main-axis** size and overrides the box's explicit `width` — so the box shrinks to the glyph's measured width (~5dp) on the main axis, while the cross-axis `height` is honored. This is why the earlier attempts with `minWidth`/`minHeight` and `flexShrink:0` had no effect: the box was being sized to its text content on the main axis, not shrunk.

The Radio never hits this because its checked child is a `<View>` dot, not text — which is exactly the one meaningful difference between the two otherwise byte-identical shells.

## Fix

Move the glyph onto its own **absolutely-positioned, flex-centered layer** so it leaves the box's content flow. With no in-flow child, the box's explicit `width` wins:

```tsx
<View style={box}>
  {filled ? (
    <View style={GLYPH_LAYER}>       {/* position:absolute, inset 0, center */}
      <Text style={glyph}>{glyph}</Text>
    </View>
  ) : null}
</View>
```

`position: absolute` + inset 0 + `alignItems/justifyContent: center` centers the glyph identically on iOS, react-native-web, and native Android — it is a cross-platform layout construct, not a `Platform.OS` branch or a web-only escape hatch. The visual result is unchanged on every platform; only the collapsed Android box is corrected. `pointerEvents: "none"` keeps the layer inert (the `Pressable` owns the touch) and stays in `style` to match the repo's current convention.

## Scope

- `src/atoms/checkbox/checkbox.shared.tsx` — glyph wrapped in the centered layer.
- No changes to the per-platform skins, so iOS/web styling is untouched. Radio is untouched.

## Verification

- `tsc --noEmit` clean.
- Full test suite: 403 pass / 3 skip. The single failing test (`Toast … auto-dismisses after its duration`) is a pre-existing flaky timer test that fails identically on the clean tree in isolation, unrelated to this change.
- Rendering checks confirm the checked box still renders the `✓` glyph and the box retains an explicit px width in the style tree; indeterminate renders the dash; unchecked renders no glyph.

> Note: the actual native-Android layout collapse is only observable in a real Fabric layout engine (the jsdom/happy-dom test env has no layout), so a meaningful automated regression test isn't feasible; the rationale is captured in a code comment so a future refactor doesn't re-inline the glyph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u5Fsha6FQp77MRS18KUJD

---
_Generated by [Claude Code](https://claude.ai/code/session_015u5Fsha6FQp77MRS18KUJD)_