### PR TITLE
fix(docs): wire Ticker into runtime example scopes so the Progress "Live" demo renders

### DIFF
--- a/docs/src/core/build-scopes.native.ts
+++ b/docs/src/core/build-scopes.native.ts
@@ -1,7 +1,7 @@
 import * as Canvas from "@olympusoss/canvas";
 import type { ColorTokens } from "@olympusoss/canvas";
 import { Platform } from "react-native";
-import { Stateful } from "./live-state";
+import { Stateful, Ticker } from "./live-state";
 import { withResolvedPhotos } from "./photos";
 import type { ExampleScope, PreviewScope } from "./scope";
 
@@ -25,6 +25,7 @@ export function buildScopes(tokens: ColorTokens): PreviewScope[] {
         MediaObject: withResolvedPhotos(Canvas.MediaObject, ["src"]),
         tokens,
         Stateful,
+        Ticker,
       } as unknown as ExampleScope,
     },
   ];

--- a/docs/src/core/build-scopes.web.ts
+++ b/docs/src/core/build-scopes.web.ts
@@ -1,7 +1,7 @@
 import * as Canvas from "@olympusoss/canvas";
 import type { ColorTokens } from "@olympusoss/canvas";
 import { PLATFORM_SKINS } from "./platform-skins";
-import { Stateful } from "./live-state";
+import { Stateful, Ticker } from "./live-state";
 import type { ExampleScope, PreviewScope } from "./scope";
 
 // Web build: render the example under all three platform skins side by side — the
@@ -10,8 +10,8 @@ import type { ExampleScope, PreviewScope } from "./scope";
 // registry. `tokens` is the live, theme-aware value, injected by the caller.
 export function buildScopes(tokens: ColorTokens): PreviewScope[] {
   return [
-    { label: "iOS", platform: "ios", scope: { ...Canvas, ...PLATFORM_SKINS.ios, tokens, Stateful } as unknown as ExampleScope },
-    { label: "Android", platform: "android", scope: { ...Canvas, ...PLATFORM_SKINS.android, tokens, Stateful } as unknown as ExampleScope },
-    { label: "Web", platform: "web", scope: { ...Canvas, tokens, Stateful } as unknown as ExampleScope },
+    { label: "iOS", platform: "ios", scope: { ...Canvas, ...PLATFORM_SKINS.ios, tokens, Stateful, Ticker } as unknown as ExampleScope },
+    { label: "Android", platform: "android", scope: { ...Canvas, ...PLATFORM_SKINS.android, tokens, Stateful, Ticker } as unknown as ExampleScope },
+    { label: "Web", platform: "web", scope: { ...Canvas, tokens, Stateful, Ticker } as unknown as ExampleScope },
   ];
 }


### PR DESCRIPTION
## Summary

The Progress component's **"Live"** docs example (`docs/src/core/examples/atoms/progress/example-1.tsx`) crashed on all three platform rows with:

> Element type is invalid: expected a string … but got: undefined. Check the render method of `PlatformRow`.

The example destructures `Ticker` from the live-example scope (`const { Ticker, … } = scope`), but `scope.Ticker` was `undefined` at render time.

## Root cause

When the `Ticker` helper was introduced (commit `f91ec2a`), it was wired into three of the four places it needs to live:

- `docs/src/core/live-state.tsx` — the helper itself (exported ✓)
- `docs/src/core/live-scope.ts` — the docgen name list, so docgen generates the `Ticker` destructure ✓
- `docs/src/core/scope.ts` — the `ExampleScope` static type ✓

…but **not** the fourth: the runtime scope builders in `build-scopes.web.ts` and `build-scopes.native.ts`. Those are what `playground.tsx` / `dont.tsx` actually pass to each example. They spread `...Canvas`, `tokens`, and `Stateful` — but never `Ticker`. So the generated destructure resolved `Ticker` to `undefined`, and React rejected the undefined element type.

`LIVE_SCOPE` (which does list `Ticker`) is only read by docgen tooling to keep destructure lists in sync; it is not the runtime scope, which is why the example passed generation but failed to render.

## Fix

Add `Ticker` alongside `Stateful` in both runtime scope builders, mirroring the existing helper wiring:

- `docs/src/core/build-scopes.web.ts` — all three (iOS / Android / Web) preview scopes
- `docs/src/core/build-scopes.native.ts` — the single device preview scope

With `Ticker` present in the runtime scope, `<Ticker values={[…]}>` resolves and the "Live" example renders — the showcase for the determinate fill + leading-edge glow catch-up.

## Scope / notes

- Docs-app-internal change only (`@olympusoss/canvas-docs` is private); the published `@olympusoss/canvas` package is untouched, so no changeset — consistent with the original `f91ec2a` (also docs-only, no changeset).
- No regeneration needed: the generated `example-1.tsx` already destructures `Ticker` correctly (it matches the `src/atoms/progress/progress.md` fence).

## Verification

- Repro: run the docs, open `/components/progress`, click the **"Live"** variant.
- The fix mirrors the `Stateful` wiring that already works today, so the same code path that renders `Stateful`-based examples now also supplies `Ticker`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QxYZmixBuwyMmmFP5mQN1Y)_